### PR TITLE
fix "type defaults to 'int'" compiler warnings

### DIFF
--- a/Source/m_cheat.c
+++ b/Source/m_cheat.c
@@ -413,7 +413,7 @@ static void cheat_noclip()
 }
 
 // 'behold?' power-up cheats (modified for infinite duration -- killough)
-static void cheat_pw(pw)
+static void cheat_pw(int pw)
 {
   if (plyr->powers[pw])
     plyr->powers[pw] = pw!=pw_strength && pw!=pw_allmap;  // killough
@@ -593,7 +593,7 @@ static void cheat_keyx()
   plyr->message = "Card, Skull";        // Ty 03/27/98 - *not* externalized
 }
 
-static void cheat_keyxx(key)
+static void cheat_keyxx(int key)
 {
   plyr->message = (plyr->cards[key] = !plyr->cards[key]) ? 
     "Key Added" : "Key Removed";  // Ty 03/27/98 - *not* externalized

--- a/Source/r_draw.c
+++ b/Source/r_draw.c
@@ -135,7 +135,7 @@ void R_DrawColumn (void)
   {
     register const byte *source = dc_source;            
     register const lighttable_t *colormap = dc_colormap; 
-    register heightmask = dc_texheight-1;
+    register int heightmask = dc_texheight-1;
     if (dc_texheight & heightmask)   // not a power of 2 -- killough
       {
         heightmask++;
@@ -235,7 +235,7 @@ void R_DrawTLColumn (void)
   {
     register const byte *source = dc_source;            
     register const lighttable_t *colormap = dc_colormap; 
-    register heightmask = dc_texheight-1;
+    register int heightmask = dc_texheight-1;
     if (dc_texheight & heightmask)   // not a power of 2 -- killough
       {
         heightmask++;


### PR DESCRIPTION
This fixes the last remaining warnings left when compiling with GCC
9.2.1 without any additional warning compiler flags.