### PR TITLE
complete overhaul of the input system

### DIFF
--- a/Source/d_net.c
+++ b/Source/d_net.c
@@ -758,6 +758,7 @@ void TryRunTics (void)
       M_Ticker ();
       return;
     } 
+    // [FG] let the CPU sleep for 1 ms if there is no tic to proceed
     I_Sleep(1);
   }
   

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -122,6 +122,7 @@ int     key_menu_down;
 int     key_menu_backspace;                                  //     ^
 int     key_menu_escape;                                     //     |
 int     key_menu_enter;                                      // phares 3/7/98
+int     key_menu_clear;
 int     key_strafeleft;
 int     key_straferight;
 int     key_fire;

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -122,6 +122,7 @@ int     key_menu_down;
 int     key_menu_backspace;                                  //     ^
 int     key_menu_escape;                                     //     |
 int     key_menu_enter;                                      // phares 3/7/98
+// [FG] clear key bindings with the DEL key
 int     key_menu_clear;
 int     key_strafeleft;
 int     key_straferight;
@@ -173,6 +174,7 @@ int     key_weapon6;
 int     key_weapon7;                                                //    ^
 int     key_weapon8;                                                //    |
 int     key_weapon9;                                                // phares
+// [FG] prev/next weapon keys and buttons
 int     key_prevweapon;
 int     key_nextweapon;
 
@@ -182,10 +184,12 @@ int     key_setup;                  // killough 10/98: shortcut to setup menu
 int     mousebfire;
 int     mousebstrafe;
 int     mousebforward;
+// [FG] prev/next weapon keys and buttons
 int     mousebprevweapon;
 int     mousebnextweapon;
 int     joybfire;
 int     joybstrafe;
+// [FG] strafe left/right joystick buttons
 int     joybstrafeleft;
 int     joybstraferight;
 int     joybuse;
@@ -447,6 +451,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
     newweapon = P_SwitchWeapon(&players[consoleplayer]);           // phares
   else
     {                                 // phares 02/26/98: Added gamemode checks
+      // [FG] prev/next weapon keys and buttons
       if (gamestate == GS_LEVEL && next_weapon != 0)
         newweapon = G_NextWeapon(next_weapon);
       else
@@ -514,6 +519,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
       cmd->buttons |= newweapon<<BT_WEAPONSHIFT;
     }
 
+    // [FG] prev/next weapon keys and buttons
     next_weapon = 0;
 
   // mouse

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -810,6 +810,18 @@ boolean G_Responder(event_t* ev)
   if (gamestate == GS_FINALE && F_Responder(ev))
     return true;  // finale ate the event
 
+    // If the next/previous weapon keys are pressed, set the next_weapon
+    // variable to change weapons when the next ticcmd is generated.
+
+    if (ev->type == ev_keydown && ev->data1 == key_prevweapon)
+    {
+        next_weapon = -1;
+    }
+    else if (ev->type == ev_keydown && ev->data1 == key_nextweapon)
+    {
+        next_weapon = 1;
+    }
+
   switch (ev->type)
     {
     case ev_keydown:

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -173,6 +173,8 @@ int     key_weapon6;
 int     key_weapon7;                                                //    ^
 int     key_weapon8;                                                //    |
 int     key_weapon9;                                                // phares
+int     key_prevweapon;
+int     key_nextweapon;
 
 int     key_screenshot;             // killough 2/22/98: screenshot key
 int     key_setup;                  // killough 10/98: shortcut to setup menu

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -183,6 +183,8 @@ int     mousebprevweapon;
 int     mousebnextweapon;
 int     joybfire;
 int     joybstrafe;
+int     joybstrafeleft;
+int     joybstraferight;
 int     joybuse;
 int     joybspeed;
 
@@ -215,7 +217,7 @@ int   dclicks2;
 // joystick values are repeated
 int   joyxmove;
 int   joyymove;
-boolean joyarray[5];
+boolean joyarray[9];
 boolean *joybuttons = &joyarray[1];    // allow [-1]
 
 int   savegameslot;
@@ -407,9 +409,9 @@ void G_BuildTiccmd(ticcmd_t* cmd)
     forward += forwardmove[speed];
   if (joyymove > 0)
     forward -= forwardmove[speed];
-  if (gamekeydown[key_straferight])
+  if (gamekeydown[key_straferight] || joybuttons[joybstraferight])
     side += sidemove[speed];
-  if (gamekeydown[key_strafeleft])
+  if (gamekeydown[key_strafeleft] || joybuttons[joybstrafeleft])
     side -= sidemove[speed];
 
     // buttons
@@ -831,6 +833,10 @@ boolean G_Responder(event_t* ev)
       joybuttons[1] = ev->data1 & 2;
       joybuttons[2] = ev->data1 & 4;
       joybuttons[3] = ev->data1 & 8;
+      joybuttons[4] = ev->data1 & 16;
+      joybuttons[5] = ev->data1 & 32;
+      joybuttons[6] = ev->data1 & 64;
+      joybuttons[7] = ev->data1 & 128;
       joyxmove = ev->data2;
       joyymove = ev->data3;
       return true;    // eat events

--- a/Source/g_game.h
+++ b/Source/g_game.h
@@ -126,6 +126,8 @@ extern int  key_weapon6;
 extern int  key_weapon7;
 extern int  key_weapon8;
 extern int  key_weapon9;                                            
+extern int  key_prevweapon;
+extern int  key_nextweapon;
 extern int  destination_keys[MAXPLAYERS];
 extern int  key_map_right;
 extern int  key_map_left;

--- a/Source/g_game.h
+++ b/Source/g_game.h
@@ -83,6 +83,7 @@ extern int  key_menu_down;
 extern int  key_menu_backspace;                              //     ^
 extern int  key_menu_escape;                                 //     |
 extern int  key_menu_enter;                                  // phares 3/7/98
+extern int  key_menu_clear;
 extern int  key_strafeleft;
 extern int  key_straferight;
 

--- a/Source/g_game.h
+++ b/Source/g_game.h
@@ -83,6 +83,7 @@ extern int  key_menu_down;
 extern int  key_menu_backspace;                              //     ^
 extern int  key_menu_escape;                                 //     |
 extern int  key_menu_enter;                                  // phares 3/7/98
+// [FG] clear key bindings with the DEL key
 extern int  key_menu_clear;
 extern int  key_strafeleft;
 extern int  key_straferight;
@@ -126,6 +127,7 @@ extern int  key_weapon6;
 extern int  key_weapon7;
 extern int  key_weapon8;
 extern int  key_weapon9;                                            
+// [FG] prev/next weapon keys and buttons
 extern int  key_prevweapon;
 extern int  key_nextweapon;
 extern int  destination_keys[MAXPLAYERS];

--- a/Source/i_video.c
+++ b/Source/i_video.c
@@ -311,7 +311,7 @@ static void UpdateMouseButtonState(unsigned int button, boolean on)
 {
     static event_t event;
 
-    if (button < SDL_BUTTON_LEFT || button > MAX_MOUSE_BUTTONS)
+    if (button < SDL_BUTTON_LEFT || button > 5)
     {
         return;
     }

--- a/Source/i_video.c
+++ b/Source/i_video.c
@@ -401,7 +401,7 @@ static void MapMouseWheelToButtons(SDL_MouseWheelEvent *wheel)
     D_PostEvent(&up);
 }
 
-void I_HandleMouseEvent(SDL_Event *sdlevent)
+static void I_HandleMouseEvent(SDL_Event *sdlevent)
 {
     switch (sdlevent->type)
     {
@@ -422,7 +422,7 @@ void I_HandleMouseEvent(SDL_Event *sdlevent)
     }
 }
 
-void I_HandleKeyboardEvent(SDL_Event *sdlevent)
+static void I_HandleKeyboardEvent(SDL_Event *sdlevent)
 {
     // XXX: passing pointers to event for access after this function
     // has terminated is undefined behaviour
@@ -622,7 +622,7 @@ static int AccelerateMouse(int val)
     }
 }
 
-void I_ReadMouse(void)
+static void I_ReadMouse(void)
 {
     int x, y;
     event_t ev;

--- a/Source/i_video.c
+++ b/Source/i_video.c
@@ -84,8 +84,10 @@ void I_JoystickEvents(void)
 
    event_t event;
    int joy_b1, joy_b2, joy_b3, joy_b4;
+   int joy_b5, joy_b6, joy_b7, joy_b8;
    Sint16 joy_x, joy_y;
    static int old_joy_b1, old_joy_b2, old_joy_b3, old_joy_b4;
+   static int old_joy_b5, old_joy_b6, old_joy_b7, old_joy_b8;
    
    if(!joystickpresent || !usejoystick || !sdlJoystick)
       return;
@@ -103,6 +105,14 @@ void I_JoystickEvents(void)
       event.data1 |= 4;
    if((joy_b4 = SDL_JoystickGetButton(sdlJoystick, 3)))
       event.data1 |= 8;
+   if((joy_b5 = SDL_JoystickGetButton(sdlJoystick, 4)))
+      event.data1 |= 16;
+   if((joy_b6 = SDL_JoystickGetButton(sdlJoystick, 5)))
+      event.data1 |= 32;
+   if((joy_b7 = SDL_JoystickGetButton(sdlJoystick, 6)))
+      event.data1 |= 64;
+   if((joy_b8 = SDL_JoystickGetButton(sdlJoystick, 7)))
+      event.data1 |= 128;
    
    // Read the x,y settings. Convert to -1 or 0 or +1.
    joy_x = SDL_JoystickGetAxis(sdlJoystick, 0);

--- a/Source/i_video.c
+++ b/Source/i_video.c
@@ -604,8 +604,8 @@ void I_GetEvent(void)
 // This is to combine all mouse movement for a tic into one mouse
 // motion event.
 
-static float mouse_acceleration = 2.0;
-static int mouse_threshold = 10;
+static const float mouse_acceleration = 2.0;
+static const int mouse_threshold = 10;
 
 static int AccelerateMouse(int val)
 {

--- a/Source/i_video.h
+++ b/Source/i_video.h
@@ -32,8 +32,6 @@
 
 #include "doomtype.h"
 
-#define MAX_MOUSE_BUTTONS 8
-
 // Called by D_DoomMain,
 // determines the hardware configuration
 // and sets up the video mode

--- a/Source/i_video.h
+++ b/Source/i_video.h
@@ -32,6 +32,8 @@
 
 #include "doomtype.h"
 
+#define MAX_MOUSE_BUTTONS 8
+
 // Called by D_DoomMain,
 // determines the hardware configuration
 // and sets up the video mode

--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -2264,6 +2264,7 @@ void M_DrawInstructions()
       flags & S_FILE   ? (s = "Type/edit filename and Press ENTER", 52)      :
       flags & S_RESET  ? 43 : 0  /* when you're changing something */        :
       flags & S_RESET  ? (s = "Press ENTER key to reset to defaults", 43)    :
+      flags & S_KEY    ? (s = "Press Enter to Change, Del to Clear", 43)    :
       (s = "Press Enter to Change", 91);
     strcpy(menu_buffer, s);
     M_DrawMenuString(x,20,color);
@@ -2365,6 +2366,7 @@ setup_menu_t keys_settings1[] =  // Key Binding screen strings
   {"BACKSPACE"   ,S_KEY       ,m_menu,KB_X,KB_Y+17*8,{&key_menu_backspace}},
   {"SELECT ITEM" ,S_KEY       ,m_menu,KB_X,KB_Y+18*8,{&key_menu_enter}},
   {"EXIT"        ,S_KEY       ,m_menu,KB_X,KB_Y+19*8,{&key_menu_escape}},
+  {"CLEAR"       ,S_KEY       ,m_menu,KB_X,KB_Y+20*8,{&key_menu_clear}},
 
   // Button for resetting to defaults
   {0,S_RESET,m_null,X_BUTTON,Y_BUTTON},
@@ -3935,6 +3937,9 @@ int M_GetKeyString(int c,int offset)
 	case KEYD_PAUSE:
 	  s = "PAUS";
 	  break;
+	case 0:
+	  s = "NONE";
+	  break;
 	default:
 	  s = "JUNK";
 	  break;
@@ -5000,6 +5005,22 @@ boolean M_Responder (event_t* ev)
 	    }
 	  while((current_setup_menu + set_menu_itemon)->m_flags & S_SKIP);
 	  M_SelectDone(current_setup_menu + set_menu_itemon);         // phares 4/17/98
+	  return true;
+	}
+
+      if (ch == key_menu_clear)
+	{
+	  if (ptr1->m_flags & S_KEY)
+	  {
+	    if (ptr1->m_joy)
+	      *ptr1->m_joy = -1;
+
+	    if (ptr1->m_mouse)
+	      *ptr1->m_mouse = -1;
+
+	    *ptr1->var.m_key = 0;
+	  }
+
 	  return true;
 	}
 

--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -239,6 +239,8 @@ extern int destination_keys[MAXPLAYERS];
 extern int mousebfire;                                   
 extern int mousebstrafe;                               
 extern int mousebforward;
+extern int mousebprevweapon;
+extern int mousebnextweapon;
 extern int joybfire;
 extern int joybstrafe;                               
 extern int joybstrafeleft;
@@ -1996,7 +1998,8 @@ void M_DrawSetting(setup_menu_t* s)
 	    }
 	  else
 	    if (key == &key_up   || key == &key_speed ||
-		key == &key_fire || key == &key_strafe || key == &key_strafeleft || key == &key_straferight)
+		key == &key_fire || key == &key_strafe || key == &key_strafeleft || key == &key_straferight ||
+		key == &key_prevweapon || key == &key_nextweapon)
 	      {
 		if (s->m_mouse)
 		  sprintf(menu_buffer+strlen(menu_buffer), "/MB%d",
@@ -2434,7 +2437,9 @@ setup_menu_t keys_settings3[] =  // Key Binding screen strings
   {"CHAINSAW",S_KEY       ,m_scrn,KB_X,KB_Y+ 8*8,{&key_weapon8}},
   {"SSG"     ,S_KEY       ,m_scrn,KB_X,KB_Y+ 9*8,{&key_weapon9}},
   {"BEST"    ,S_KEY       ,m_scrn,KB_X,KB_Y+10*8,{&key_weapontoggle}},
-  {"FIRE"    ,S_KEY       ,m_scrn,KB_X,KB_Y+11*8,{&key_fire},&mousebfire,&joybfire},
+  {"PREV"    ,S_KEY       ,m_scrn,KB_X,KB_Y+11*8,{&key_prevweapon},&mousebprevweapon,0},
+  {"NEXT"    ,S_KEY       ,m_scrn,KB_X,KB_Y+12*8,{&key_nextweapon},&mousebnextweapon,0},
+  {"FIRE"    ,S_KEY       ,m_scrn,KB_X,KB_Y+13*8,{&key_fire},&mousebfire,&joybfire},
 
   {"<- PREV",S_SKIP|S_PREV,m_null,KB_PREV,KB_Y+20*8, {keys_settings2}},
   {"NEXT ->",S_SKIP|S_NEXT,m_null,KB_NEXT,KB_Y+20*8, {keys_settings4}},
@@ -3937,6 +3942,9 @@ int M_GetKeyString(int c,int offset)
 	case KEYD_PAUSE:
 	  s = "PAUS";
 	  break;
+	case KEYD_DEL:
+	  s = "DEL";
+	  break;
 	case 0:
 	  s = "NONE";
 	  break;
@@ -4239,7 +4247,7 @@ boolean M_Responder (event_t* ev)
 	      ch = 0; // meaningless, just to get you past the check for -1
 	      joywait = I_GetTime() + 5;
 	    }
-	  if (ev->data1&8)
+	  if (ev->data1&8 || ev->data1&16 || ev->data1&32 || ev->data1&64 || ev->data1&128)
 	    {
 	      ch = 0; // meaningless, just to get you past the check for -1
 	      joywait = I_GetTime() + 5;
@@ -4299,7 +4307,7 @@ boolean M_Responder (event_t* ev)
 	  // to where key binding can eat it.
 
 	  if (setup_active && set_keybnd_active)
-	    if (ev->data1&4)
+	    if (ev->data1&4 || ev->data1&8 || ev->data1&16)
 	      {
 		ch = 0; // meaningless, just to get you past the check for -1
 		mousewait = I_GetTime() + 15;
@@ -4737,6 +4745,14 @@ boolean M_Responder (event_t* ev)
 		  ch = 2;
 		else if (ev->data1 & 8)
 		  ch = 3;
+		else if (ev->data1 & 16)
+		  ch = 4;
+		else if (ev->data1 & 32)
+		  ch = 5;
+		else if (ev->data1 & 64)
+		  ch = 6;
+		else if (ev->data1 & 128)
+		  ch = 7;
 		else
 		  return true;
 		for (i = 0 ; keys_settings[i] && search ; i++)
@@ -4774,6 +4790,10 @@ boolean M_Responder (event_t* ev)
 		  ch = 1;
 		else if (ev->data1 & 4)
 		  ch = 2;
+		else if (ev->data1 & 8)
+		  ch = 3;
+		else if (ev->data1 & 16)
+		  ch = 4;
 		else
 		  return true;
 		for (i = 0 ; keys_settings[i] && search ; i++)

--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -1998,7 +1998,8 @@ void M_DrawSetting(setup_menu_t* s)
 	    }
 	  else
 	    if (key == &key_up   || key == &key_speed ||
-		key == &key_fire || key == &key_strafe || key == &key_strafeleft || key == &key_straferight ||
+		key == &key_fire || key == &key_strafe ||
+		key == &key_strafeleft || key == &key_straferight ||
 		key == &key_prevweapon || key == &key_nextweapon)
 	      {
 		if (s->m_mouse)

--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -239,10 +239,12 @@ extern int destination_keys[MAXPLAYERS];
 extern int mousebfire;                                   
 extern int mousebstrafe;                               
 extern int mousebforward;
+// [FG] prev/next weapon keys and buttons
 extern int mousebprevweapon;
 extern int mousebnextweapon;
 extern int joybfire;
 extern int joybstrafe;                               
+// [FG] strafe left/right joystick buttons
 extern int joybstrafeleft;
 extern int joybstraferight;
 extern int joybuse;                                   
@@ -1999,7 +2001,9 @@ void M_DrawSetting(setup_menu_t* s)
 	  else
 	    if (key == &key_up   || key == &key_speed ||
 		key == &key_fire || key == &key_strafe ||
+		// [FG] strafe left/right joystick buttons
 		key == &key_strafeleft || key == &key_straferight ||
+		// [FG] prev/next weapon keys and buttons
 		key == &key_prevweapon || key == &key_nextweapon)
 	      {
 		if (s->m_mouse)
@@ -2268,6 +2272,7 @@ void M_DrawInstructions()
       flags & S_FILE   ? (s = "Type/edit filename and Press ENTER", 52)      :
       flags & S_RESET  ? 43 : 0  /* when you're changing something */        :
       flags & S_RESET  ? (s = "Press ENTER key to reset to defaults", 43)    :
+      // [FG] clear key bindings with the DEL key
       flags & S_KEY    ? (s = "Press Enter to Change, Del to Clear", 43)    :
       (s = "Press Enter to Change", 91);
     strcpy(menu_buffer, s);
@@ -2370,6 +2375,7 @@ setup_menu_t keys_settings1[] =  // Key Binding screen strings
   {"BACKSPACE"   ,S_KEY       ,m_menu,KB_X,KB_Y+17*8,{&key_menu_backspace}},
   {"SELECT ITEM" ,S_KEY       ,m_menu,KB_X,KB_Y+18*8,{&key_menu_enter}},
   {"EXIT"        ,S_KEY       ,m_menu,KB_X,KB_Y+19*8,{&key_menu_escape}},
+  // [FG] clear key bindings with the DEL key
   {"CLEAR"       ,S_KEY       ,m_menu,KB_X,KB_Y+20*8,{&key_menu_clear}},
 
   // Button for resetting to defaults
@@ -2438,6 +2444,7 @@ setup_menu_t keys_settings3[] =  // Key Binding screen strings
   {"CHAINSAW",S_KEY       ,m_scrn,KB_X,KB_Y+ 8*8,{&key_weapon8}},
   {"SSG"     ,S_KEY       ,m_scrn,KB_X,KB_Y+ 9*8,{&key_weapon9}},
   {"BEST"    ,S_KEY       ,m_scrn,KB_X,KB_Y+10*8,{&key_weapontoggle}},
+  // [FG] prev/next weapon keys and buttons
   {"PREV"    ,S_KEY       ,m_scrn,KB_X,KB_Y+11*8,{&key_prevweapon},&mousebprevweapon,0},
   {"NEXT"    ,S_KEY       ,m_scrn,KB_X,KB_Y+12*8,{&key_nextweapon},&mousebnextweapon,0},
   {"FIRE"    ,S_KEY       ,m_scrn,KB_X,KB_Y+13*8,{&key_fire},&mousebfire,&joybfire},
@@ -3943,6 +3950,7 @@ int M_GetKeyString(int c,int offset)
 	case KEYD_PAUSE:
 	  s = "PAUS";
 	  break;
+	// [FG] clear key bindings with the DEL key
 	case KEYD_DEL:
 	  s = "DEL";
 	  break;
@@ -5029,6 +5037,7 @@ boolean M_Responder (event_t* ev)
 	  return true;
 	}
 
+      // [FG] clear key bindings with the DEL key
       if (ch == key_menu_clear)
 	{
 	  if (ptr1->m_flags & S_KEY)

--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -241,6 +241,8 @@ extern int mousebstrafe;
 extern int mousebforward;
 extern int joybfire;
 extern int joybstrafe;                               
+extern int joybstrafeleft;
+extern int joybstraferight;
 extern int joybuse;                                   
 extern int joybspeed;                                     
 extern int default_weapon_recoil;   // weapon recoil        
@@ -1994,7 +1996,7 @@ void M_DrawSetting(setup_menu_t* s)
 	    }
 	  else
 	    if (key == &key_up   || key == &key_speed ||
-		key == &key_fire || key == &key_strafe)
+		key == &key_fire || key == &key_strafe || key == &key_strafeleft || key == &key_straferight)
 	      {
 		if (s->m_mouse)
 		  sprintf(menu_buffer+strlen(menu_buffer), "/MB%d",
@@ -2348,8 +2350,8 @@ setup_menu_t keys_settings1[] =  // Key Binding screen strings
   {"TURN LEFT"   ,S_KEY       ,m_scrn,KB_X,KB_Y+3*8,{&key_left}},
   {"TURN RIGHT"  ,S_KEY       ,m_scrn,KB_X,KB_Y+4*8,{&key_right}},
   {"RUN"         ,S_KEY       ,m_scrn,KB_X,KB_Y+5*8,{&key_speed},0,&joybspeed},
-  {"STRAFE LEFT" ,S_KEY       ,m_scrn,KB_X,KB_Y+6*8,{&key_strafeleft}},
-  {"STRAFE RIGHT",S_KEY       ,m_scrn,KB_X,KB_Y+7*8,{&key_straferight}},
+  {"STRAFE LEFT" ,S_KEY       ,m_scrn,KB_X,KB_Y+6*8,{&key_strafeleft},0,&joybstrafeleft},
+  {"STRAFE RIGHT",S_KEY       ,m_scrn,KB_X,KB_Y+7*8,{&key_straferight},0,&joybstraferight},
   {"STRAFE"      ,S_KEY       ,m_scrn,KB_X,KB_Y+8*8,{&key_strafe},&mousebstrafe,&joybstrafe},
   {"AUTORUN"     ,S_KEY       ,m_scrn,KB_X,KB_Y+9*8,{&key_autorun}},
   {"180 TURN"    ,S_KEY       ,m_scrn,KB_X,KB_Y+10*8,{&key_reverse}},
@@ -3999,8 +4001,8 @@ setup_menu_t helpstrings[] =  // HELP screen strings
   {"TURN LEFT"   ,S_SKIP|S_KEY,m_null,KT_X3,KT_Y3+ 3*8,{&key_left}},
   {"TURN RIGHT"  ,S_SKIP|S_KEY,m_null,KT_X3,KT_Y3+ 4*8,{&key_right}},
   {"RUN"         ,S_SKIP|S_KEY,m_null,KT_X3,KT_Y3+ 5*8,{&key_speed},0,&joybspeed},
-  {"STRAFE LEFT" ,S_SKIP|S_KEY,m_null,KT_X3,KT_Y3+ 6*8,{&key_strafeleft}},
-  {"STRAFE RIGHT",S_SKIP|S_KEY,m_null,KT_X3,KT_Y3+ 7*8,{&key_straferight}},
+  {"STRAFE LEFT" ,S_SKIP|S_KEY,m_null,KT_X3,KT_Y3+ 6*8,{&key_strafeleft},0,&joybstrafeleft},
+  {"STRAFE RIGHT",S_SKIP|S_KEY,m_null,KT_X3,KT_Y3+ 7*8,{&key_straferight},0,&joybstraferight},
   {"STRAFE"      ,S_SKIP|S_KEY,m_null,KT_X3,KT_Y3+ 8*8,{&key_strafe},&mousebstrafe,&joybstrafe},
   {"AUTORUN"     ,S_SKIP|S_KEY,m_null,KT_X3,KT_Y3+ 9*8,{&key_autorun}},
   {"180 TURN"    ,S_SKIP|S_KEY,m_null,KT_X3,KT_Y3+10*8,{&key_reverse}},

--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -64,10 +64,12 @@ int screenshot_pcx; //jff 3/30/98 // option to output screenshot as pcx or bmp
 extern int mousebfire;
 extern int mousebstrafe;
 extern int mousebforward;
+// [FG] prev/next weapon keys and buttons
 extern int mousebprevweapon;
 extern int mousebnextweapon;
 extern int joybfire;
 extern int joybstrafe;
+// [FG] strafe left/right joystick buttons
 extern int joybstrafeleft;
 extern int joybstraferight;
 extern int joybuse;
@@ -661,7 +663,7 @@ default_t defaults[] = {
     "key to select from menu or review past messages"
   },
 
-  {
+  { // [FG] clear key bindings with the DEL key
     "key_menu_clear",
     &key_menu_clear, NULL,
     KEYD_DEL, {0,255}, number, ss_keys, wad_no,
@@ -962,7 +964,7 @@ default_t defaults[] = {
     "key to toggle between two most preferred weapons with ammo"
   },
 
-  {
+  { // [FG] prev/next weapon keys and buttons
     "key_prevweapon",
     &key_prevweapon, NULL,
     0, {0,255}, number, ss_keys, wad_no,
@@ -1092,7 +1094,7 @@ default_t defaults[] = {
     "mouse button number to use for forward motion (-1 = disable)"
   }, //jff 3/8/98 end of lower range change for -1 allowed in mouse binding
 
-  {
+  { // [FG] prev/next weapon keys and buttons
     "mouseb_prevweapon",
     &mousebprevweapon, NULL,
     4, {-1,4}, number, ss_keys, wad_no,
@@ -1141,7 +1143,7 @@ default_t defaults[] = {
     "joystick button number to use for use/open"
   },
 
-  {
+  { // [FG] strafe left/right joystick buttons
     "joyb_strafeleft",
     &joybstrafeleft, NULL,
     4, {0,UL}, 0, ss_keys, wad_no,

--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -963,6 +963,20 @@ default_t defaults[] = {
   },
 
   {
+    "key_prevweapon",
+    &key_prevweapon, NULL,
+    0, {0,255}, number, ss_keys, wad_no,
+    "key to cycle to the previous weapon"
+  },
+
+  {
+    "key_nextweapon",
+    &key_nextweapon, NULL,
+    0, {0,255}, number, ss_keys, wad_no,
+    "key to cycle to the next weapon"
+  },
+
+  {
     "key_weapon1",
     &key_weapon1, NULL,
     '1', {0,255}, number, ss_keys, wad_no,

--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -68,6 +68,8 @@ extern int mousebprevweapon;
 extern int mousebnextweapon;
 extern int joybfire;
 extern int joybstrafe;
+extern int joybstrafeleft;
+extern int joybstraferight;
 extern int joybuse;
 extern int joybspeed;
 extern int viewwidth;
@@ -1118,6 +1120,20 @@ default_t defaults[] = {
     "joystick button number to use for use/open"
   },
 
+  {
+    "joyb_strafeleft",
+    &joybstrafeleft, NULL,
+    4, {0,UL}, 0, ss_keys, wad_no,
+    "joystick button number to strafe left (sideways left)"
+  },
+
+  {
+    "joyb_straferight",
+    &joybstraferight, NULL,
+    5, {0,UL}, 0, ss_keys, wad_no,
+    "joystick button number to strafe right (sideways right)"
+  },
+
   { // killough
     "snd_channels",
     &default_numChannels, NULL,
@@ -1635,7 +1651,7 @@ default_t defaults[] = {
   {
     "joystick_num",
     &i_SDLJoystickNum, NULL,
-    -1, {-1,UL}, number, ss_none, wad_no,
+    0, {-1,UL}, number, ss_none, wad_no,
     "SDL joystick device number, -1 to disable"
   },
     

--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -64,6 +64,8 @@ int screenshot_pcx; //jff 3/30/98 // option to output screenshot as pcx or bmp
 extern int mousebfire;
 extern int mousebstrafe;
 extern int mousebforward;
+extern int mousebprevweapon;
+extern int mousebnextweapon;
 extern int joybfire;
 extern int joybstrafe;
 extern int joybuse;
@@ -1049,23 +1051,37 @@ default_t defaults[] = {
   { //jff 3/8/98 allow -1 in mouse bindings to disable mouse function
     "mouseb_fire",
     &mousebfire, NULL,
-    0, {-1,2}, number, ss_keys, wad_no,
+    0, {-1,4}, number, ss_keys, wad_no,
     "mouse button number to use for fire (-1 = disable)"
   },
 
   {
     "mouseb_strafe",
     &mousebstrafe, NULL,
-    1, {-1,2}, number, ss_keys, wad_no,
+    1, {-1,4}, number, ss_keys, wad_no,
     "mouse button number to use for strafing (-1 = disable)"
   },
 
   {
     "mouseb_forward",
     &mousebforward, NULL,
-    2, {-1,2}, number, ss_keys, wad_no,
+    2, {-1,4}, number, ss_keys, wad_no,
     "mouse button number to use for forward motion (-1 = disable)"
   }, //jff 3/8/98 end of lower range change for -1 allowed in mouse binding
+
+  {
+    "mouseb_prevweapon",
+    &mousebprevweapon, NULL,
+    4, {-1,4}, number, ss_keys, wad_no,
+    "mouse button number to cycle to the previous weapon (-1 = disable)"
+  },
+
+  {
+    "mouseb_nextweapon",
+    &mousebnextweapon, NULL,
+    3, {-1,4}, number, ss_keys, wad_no,
+    "mouse button number to cycle to the mext weapon (-1 = disable)"
+  },
 
   {
     "use_joystick",

--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -662,6 +662,13 @@ default_t defaults[] = {
   },
 
   {
+    "key_menu_clear",
+    &key_menu_clear, NULL,
+    KEYD_DEL, {0,255}, number, ss_keys, wad_no,
+    "key to clear a key binding"
+  },
+
+  {
     "key_strafeleft",
     &key_strafeleft, NULL,
     ',', {0,255}, number, ss_keys, wad_no,


### PR DESCRIPTION
 * Port over the entire mouse movement and buttons handling code from Chocolate Doom 3.0 (Fixes #9).
 * Add next/prev weapon switching from Chocolate Doom 3.0.
 * Support up to 5 mouse buttons, map mouse wheel to buttons 4 and 5 and bind them to next/prev weapon respectively.
 * Add next/prev weapon key bindings, leave unbound.
 * Add the ability to clear menu bindings (Fixes #10), bind to the DEL key.
 * Leave the joystick handling code as it was with SDL1.2 (which still works fine for my SNES style gamepad), but support up to 8 joystick buttons. Map buttons 4 and 5 to strafe left/right, respectively.
 * Use joystick device number 0 by default, but leave use_joystick at 0 (to be enabled through the menu).