### PR TITLE
add support for more IWADs

### DIFF
--- a/Source/d_main.c
+++ b/Source/d_main.c
@@ -135,8 +135,15 @@ const char *const standard_iwads[]=
   "/tnt.wad",
   "/doom.wad",
   "/doom1.wad",
+  // [FG] support the FreeDoom IWADs
+  "/freedoom2.wad",
+  "/freedoom1.wad",
+  "/freedm.wad",
 };
 static const int nstandard_iwads = sizeof standard_iwads/sizeof*standard_iwads;
+
+// [FG] support the BFG Edition IWADs
+int bfgedition = 0;
 
 void D_CheckNetGame (void);
 void D_ProcessEvents (void);
@@ -491,7 +498,9 @@ void D_DoAdvanceDemo(void)
   if (!demostates[++demosequence][gamemode].func)
     demosequence = 0;
   demostates[demosequence][gamemode].func
-    (demostates[demosequence][gamemode].name);
+    // [FG] the BFG Edition IWADs have no TITLEPIC lump, use DMENUPIC instead
+    ((bfgedition && strncmp(demostates[demosequence][gamemode].name,"TITLEPIC",8) == 0) ? "DMENUPIC" :
+     demostates[demosequence][gamemode].name);
 }
 
 //
@@ -605,6 +614,7 @@ static void CheckIWAD(const char *iwadname,
   filelump_t lump;
   wadinfo_t header;
   const char *n = lump.name;
+  boolean noiwad = 0;
 
   if (!fp)
     I_Error("Can't open IWAD: %s\n",iwadname);
@@ -613,7 +623,8 @@ static void CheckIWAD(const char *iwadname,
   if (fread(&header, 1, sizeof header, fp) != sizeof header ||
       header.identification[0] != 'I' || header.identification[1] != 'W' ||
       header.identification[2] != 'A' || header.identification[3] != 'D')
-    I_Error("IWAD tag not present: %s\n",iwadname);
+    // [FG] the BFG Edition IWADs have a PWAD signature
+    ++noiwad;
 
   fseek(fp, LONG(header.infotableofs), SEEK_SET);
 
@@ -623,6 +634,7 @@ static void CheckIWAD(const char *iwadname,
 
   for (ud=rg=sw=cm=sc=tnt=plut=0, header.numlumps = LONG(header.numlumps);
        header.numlumps && fread(&lump, sizeof lump, 1, fp); header.numlumps--)
+{
     *n=='E' && n[2]=='M' && !n[4] ?
       n[1]=='4' ? ++ud : n[1]!='1' ? rg += n[1]=='3' || n[1]=='2' : ++sw :
     *n=='M' && n[1]=='A' && n[2]=='P' && !n[5] ?
@@ -630,13 +642,21 @@ static void CheckIWAD(const char *iwadname,
     *n=='C' && n[1]=='A' && n[2]=='V' && !n[7] ? ++tnt :
     *n=='M' && n[1]=='C' && !n[3] && ++plut;
 
+    // [FG] identify the BFG Edition IWADs by their DMENUPIC lump
+    if (strncmp(n,"DMENUPIC",8) == 0)
+      ++bfgedition;
+}
+
   fclose(fp);
+  if (noiwad && !bfgedition)
+    I_Error("IWAD tag not present: %s\n",iwadname);
 
   *gmission = doom;
   *hassec = false;
   *gmode =
-    cm >= 30 ? (*gmission = tnt >= 4 ? pack_tnt :
-                plut >= 8 ? pack_plut : doom2,
+    // [FG] improve gamemission detection to support the FreeDoom IWADs
+    cm >= 30 ? (*gmission = (tnt >= 4 && plut < 8) ? pack_tnt :
+                (plut >= 8 && tnt < 4) ? pack_plut : doom2,
                 *hassec = sc >= 2, commercial) :
     ud >= 9 ? retail :
     rg >= 18 ? registered :

--- a/Source/doomdef.h
+++ b/Source/doomdef.h
@@ -77,6 +77,9 @@ typedef enum {
   unknown
 } Language_t;
 
+// [FG] support the BFG Edition IWADs
+extern int bfgedition;
+
 //
 // For resize of screen, at start of game.
 //

--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -5692,6 +5692,12 @@ void M_Init(void)
   M_ResetMenu();        // killough 10/98
   M_InitHelpScreen();   // init the help screen       // phares 4/08/98
   M_InitExtendedHelp(); // init extended help screens // phares 3/30/98
+
+  // [FG] support the BFG Edition IWADs
+  if (bfgedition)
+  {
+    strcpy(OptionsMenu[scrnsize].name, "M_DISP");
+  }
 }
 
 // killough 10/98: allow runtime changing of menu order


### PR DESCRIPTION
More specifically, add support for the FreeDoom IWADs and for the
IWADs that are shipped with the Doom Classic engine that is used for
the Doom 3: BFG Edition.

 * Add the three FreeDoom IWADs to the standard_iwads[] array.
 * Improve the gamemissions detection, because freedoom2.wad contains
   characteristic lumps of both Plutonia and TNT.
 * Fixes #4.

 * Identify the BFG Edition IWADs by their unique DMENUPIC lump.
 * The BFG Edition IWADs have a PWAD signature, so be more forgiving
   in CheckIWAD().
 * Since the BFG Edition IWADs are missing the TITLEPIC lump, use the
   DMENUPIC lump instead.
 * Since the BFG Edition IWADs have their M_SCRNSZ menu graphic lump
   read "Gamepad:", use the unused M_DISP lump instead which reads
   "Display".
 * Fixes #3.