### PR TITLE
fullscreen toggle from the video menu

### DIFF
--- a/Source/i_video.c
+++ b/Source/i_video.c
@@ -433,6 +433,8 @@ static void I_HandleKeyboardEvent(SDL_Event *sdlevent)
         case SDL_KEYDOWN:
             event.type = ev_keydown;
             event.data1 = TranslateKey(&sdlevent->key.keysym);
+            event.data2 = 0;
+            event.data3 = 0;
 /*
             event.data2 = GetLocalizedKey(&sdlevent->key.keysym);
             event.data3 = GetTypedChar(&sdlevent->key.keysym);
@@ -537,6 +539,13 @@ static void I_ToggleFullScreen(void)
     {
         SDL_SetWindowSize(screen, window_width, window_height);
     }
+}
+
+void I_ToggleToggleFullScreen(void)
+{
+    fullscreen = !fullscreen;
+
+    I_ToggleFullScreen();
 }
 
 // killough 3/22/98: rewritten to use interrupt-driven keyboard queue

--- a/Source/i_video.c
+++ b/Source/i_video.c
@@ -541,6 +541,9 @@ static void I_ToggleFullScreen(void)
     }
 }
 
+// [FG] the fullscreen variable gets toggled once by the menu code, so we
+// toggle it back here, it is then toggled again in I_ToggleFullScreen()
+
 void I_ToggleToggleFullScreen(void)
 {
     fullscreen = !fullscreen;

--- a/Source/i_video.h
+++ b/Source/i_video.h
@@ -55,6 +55,7 @@ int I_DoomCode2ScanCode(int);   // killough
 int I_ScanCode2DoomCode(int);   // killough
 
 void I_ResetScreen(void);   // killough 10/98
+void I_ToggleToggleFullScreen(void);
 
 extern int use_vsync;  // killough 2/8/98: controls whether vsync is called
 extern int page_flip;  // killough 8/15/98: enables page flipping (320x200)

--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -3037,7 +3037,6 @@ setup_menu_t* gen_settings[] =
 
 enum {
   general_hires,  
-  general_fullscreen,
   general_pageflip,
   general_vsync,
   general_trans,
@@ -3045,6 +3044,7 @@ enum {
   general_pcx,
   general_diskicon,
   general_hom
+, general_fullscreen
 };
 
 enum {
@@ -3059,7 +3059,7 @@ enum {
 
 #define G_X 250
 #define G_Y  44
-#define G_Y2 (G_Y+82+10)
+#define G_Y2 (G_Y+82+16)
 #define G_Y3 (G_Y+44)
 #define G_Y4 (G_Y3+52)
 #define GF_X 76
@@ -3070,9 +3070,6 @@ setup_menu_t gen_settings1[] = { // General Settings screen1
 
   {"High Resolution", S_YESNO, m_null, G_X, G_Y + general_hires*8,
    {"hires"}, 0, 0, I_ResetScreen},
-
-  {"Fullscreen Mode", S_YESNO, m_null, G_X, G_Y + general_fullscreen*8,
-   {"fullscreen"}, 0, 0, I_ToggleToggleFullScreen},
 
 #if 0 // SDL2
   {"Use Page-Flipping", S_YESNO, m_null, G_X, G_Y + general_pageflip*8,
@@ -3102,6 +3099,9 @@ setup_menu_t gen_settings1[] = { // General Settings screen1
 
   {"Flashing HOM indicator", S_YESNO, m_null, G_X,
    G_Y + general_hom*8, {"flashing_hom"}},
+
+  {"Fullscreen Mode", S_YESNO, m_null, G_X, G_Y + general_fullscreen*8,
+   {"fullscreen"}, 0, 0, I_ToggleToggleFullScreen},
 
   {"Sound & Music", S_SKIP|S_TITLE, m_null, G_X, G_Y2 - 12},
 

--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -2375,8 +2375,10 @@ setup_menu_t keys_settings1[] =  // Key Binding screen strings
   {"BACKSPACE"   ,S_KEY       ,m_menu,KB_X,KB_Y+17*8,{&key_menu_backspace}},
   {"SELECT ITEM" ,S_KEY       ,m_menu,KB_X,KB_Y+18*8,{&key_menu_enter}},
   {"EXIT"        ,S_KEY       ,m_menu,KB_X,KB_Y+19*8,{&key_menu_escape}},
+/*
   // [FG] clear key bindings with the DEL key
   {"CLEAR"       ,S_KEY       ,m_menu,KB_X,KB_Y+20*8,{&key_menu_clear}},
+*/
 
   // Button for resetting to defaults
   {0,S_RESET,m_null,X_BUTTON,Y_BUTTON},
@@ -2444,10 +2446,10 @@ setup_menu_t keys_settings3[] =  // Key Binding screen strings
   {"CHAINSAW",S_KEY       ,m_scrn,KB_X,KB_Y+ 8*8,{&key_weapon8}},
   {"SSG"     ,S_KEY       ,m_scrn,KB_X,KB_Y+ 9*8,{&key_weapon9}},
   {"BEST"    ,S_KEY       ,m_scrn,KB_X,KB_Y+10*8,{&key_weapontoggle}},
+  {"FIRE"    ,S_KEY       ,m_scrn,KB_X,KB_Y+11*8,{&key_fire},&mousebfire,&joybfire},
   // [FG] prev/next weapon keys and buttons
-  {"PREV"    ,S_KEY       ,m_scrn,KB_X,KB_Y+11*8,{&key_prevweapon},&mousebprevweapon,0},
-  {"NEXT"    ,S_KEY       ,m_scrn,KB_X,KB_Y+12*8,{&key_nextweapon},&mousebnextweapon,0},
-  {"FIRE"    ,S_KEY       ,m_scrn,KB_X,KB_Y+13*8,{&key_fire},&mousebfire,&joybfire},
+  {"PREV"    ,S_KEY       ,m_scrn,KB_X,KB_Y+12*8,{&key_prevweapon},&mousebprevweapon,0},
+  {"NEXT"    ,S_KEY       ,m_scrn,KB_X,KB_Y+13*8,{&key_nextweapon},&mousebnextweapon,0},
 
   {"<- PREV",S_SKIP|S_PREV,m_null,KB_PREV,KB_Y+20*8, {keys_settings2}},
   {"NEXT ->",S_SKIP|S_NEXT,m_null,KB_NEXT,KB_Y+20*8, {keys_settings4}},
@@ -3035,6 +3037,7 @@ setup_menu_t* gen_settings[] =
 
 enum {
   general_hires,  
+  general_fullscreen,
   general_pageflip,
   general_vsync,
   general_trans,
@@ -3045,8 +3048,10 @@ enum {
 };
 
 enum {
+/*
   general_sndcard,
   general_muscard,
+*/
   general_detvoices,
   general_sndchan,
   general_pitch
@@ -3054,7 +3059,7 @@ enum {
 
 #define G_X 250
 #define G_Y  44
-#define G_Y2 (G_Y+82)
+#define G_Y2 (G_Y+82+10)
 #define G_Y3 (G_Y+44)
 #define G_Y4 (G_Y3+52)
 #define GF_X 76
@@ -3065,6 +3070,9 @@ setup_menu_t gen_settings1[] = { // General Settings screen1
 
   {"High Resolution", S_YESNO, m_null, G_X, G_Y + general_hires*8,
    {"hires"}, 0, 0, I_ResetScreen},
+
+  {"Fullscreen Mode", S_YESNO, m_null, G_X, G_Y + general_fullscreen*8,
+   {"fullscreen"}, 0, 0, I_ToggleToggleFullScreen},
 
 #if 0 // SDL2
   {"Use Page-Flipping", S_YESNO, m_null, G_X, G_Y + general_pageflip*8,
@@ -3097,11 +3105,13 @@ setup_menu_t gen_settings1[] = { // General Settings screen1
 
   {"Sound & Music", S_SKIP|S_TITLE, m_null, G_X, G_Y2 - 12},
 
+/*
   {"Sound Card", S_NUM|S_PRGWARN, m_null, G_X,
    G_Y2 + general_sndcard*8, {"sound_card"}},
 
   {"Music Card", S_NUM|S_PRGWARN, m_null, G_X,
    G_Y2 + general_muscard*8, {"music_card"}},
+*/
 
   {"Autodetect Number of Voices", S_YESNO|S_PRGWARN, m_null, G_X,
    G_Y2 + general_detvoices*8, {"detect_voices"}},


### PR DESCRIPTION
This appends a "Fullscreen Mode" entry to the Video menu.

While at it, clean up the previous menu changes a bit. Added menu entries are always appended to the end of a menu. Remove the now useless sound and music card selection entries.