### PR TITLE
upgrade the renderer to use 32-bit integer math

### DIFF
--- a/Source/r_defs.h
+++ b/Source/r_defs.h
@@ -303,7 +303,7 @@ typedef struct drawseg_s
   // Pointers to lists for sprite clipping,
   // all three adjusted so [x1] is first value.
 
-  short *sprtopclip, *sprbottomclip, *maskedtexturecol;
+  int *sprtopclip, *sprbottomclip, *maskedtexturecol;
 } drawseg_t;
 
 //
@@ -401,11 +401,11 @@ typedef struct visplane
   int picnum, lightlevel, minx, maxx;
   fixed_t height;
   fixed_t xoffs, yoffs;         // killough 2/28/98: Support scrolling flats
-  unsigned short pad1;          // leave pads for [minx-1]/[maxx+1]
-  unsigned short top[MAX_SCREENWIDTH];
-  unsigned short pad2, pad3;    // killough 2/8/98, 4/25/98
-  unsigned short bottom[MAX_SCREENWIDTH];
-  unsigned short pad4;
+  unsigned int pad1;          // leave pads for [minx-1]/[maxx+1]
+  unsigned int top[MAX_SCREENWIDTH];
+  unsigned int pad2, pad3;    // killough 2/8/98, 4/25/98
+  unsigned int bottom[MAX_SCREENWIDTH];
+  unsigned int pad4;
 } visplane_t;
 
 #endif

--- a/Source/r_defs.h
+++ b/Source/r_defs.h
@@ -303,7 +303,7 @@ typedef struct drawseg_s
   // Pointers to lists for sprite clipping,
   // all three adjusted so [x1] is first value.
 
-  int *sprtopclip, *sprbottomclip, *maskedtexturecol;
+  int *sprtopclip, *sprbottomclip, *maskedtexturecol; // [FG] 32-bit integer math
 } drawseg_t;
 
 //
@@ -401,6 +401,7 @@ typedef struct visplane
   int picnum, lightlevel, minx, maxx;
   fixed_t height;
   fixed_t xoffs, yoffs;         // killough 2/28/98: Support scrolling flats
+  // [FG] 32-bit integer math
   unsigned int pad1;          // leave pads for [minx-1]/[maxx+1]
   unsigned int top[MAX_SCREENWIDTH];
   unsigned int pad2, pad3;    // killough 2/8/98, 4/25/98

--- a/Source/r_plane.c
+++ b/Source/r_plane.c
@@ -66,13 +66,13 @@ visplane_t *floorplane, *ceilingplane;
 // killough 8/1/98: set static number of openings to be large enough
 // (a static limit is okay in this case and avoids difficulties in r_segs.c)
 #define MAXOPENINGS (MAX_SCREENWIDTH*MAX_SCREENHEIGHT)
-short openings[MAXOPENINGS],*lastopening;
+int openings[MAXOPENINGS],*lastopening;
 
 // Clip values are the solid pixel bounding the range.
 //  floorclip starts out SCREENHEIGHT
 //  ceilingclip starts out -1
 
-short floorclip[MAX_SCREENWIDTH], ceilingclip[MAX_SCREENWIDTH];
+int floorclip[MAX_SCREENWIDTH], ceilingclip[MAX_SCREENWIDTH];
 
 // spanstart holds the start of a plane span; initialized to 0 at start
 
@@ -269,7 +269,7 @@ visplane_t *R_CheckPlane(visplane_t *pl, int start, int stop)
   else
     unionh  = pl->maxx, intrh  = stop;
 
-  for (x=intrl ; x <= intrh && pl->top[x] == 0xffff; x++)
+  for (x=intrl ; x <= intrh && pl->top[x] == 0xffffffffu; x++)
     ;
 
   if (x > intrh)
@@ -297,7 +297,7 @@ visplane_t *R_CheckPlane(visplane_t *pl, int start, int stop)
 // R_MakeSpans
 //
 
-static void R_MakeSpans(int x, int t1, int b1, int t2, int b2)
+static void R_MakeSpans(int x, unsigned int t1, unsigned int b1, unsigned int t2, unsigned int b2)
 {
   for (; t1 < t2 && t1 <= b1; t1++)
     R_MapPlane(t1, spanstart[t1], x-1);
@@ -378,7 +378,7 @@ static void do_draw_plane(visplane_t *pl)
 
 	// killough 10/98: Use sky scrolling offset, and possibly flip picture
         for (x = pl->minx; (dc_x = x) <= pl->maxx; x++)
-          if ((dc_yl = pl->top[x]) <= (dc_yh = pl->bottom[x]))
+          if ((unsigned)(dc_yl = pl->top[x]) <= (dc_yh = pl->bottom[x]))
             {
               dc_source = R_GetColumn(texture, ((an + xtoviewangle[x])^flip) >>
 				      ANGLETOSKYSHIFT);
@@ -405,7 +405,7 @@ static void do_draw_plane(visplane_t *pl)
 
         stop = pl->maxx + 1;
         planezlight = zlight[light];
-        pl->top[pl->minx-1] = pl->top[stop] = 0xffff;
+        pl->top[pl->minx-1] = pl->top[stop] = 0xffffffffu;
 
         for (x = pl->minx ; x <= stop ; x++)
           R_MakeSpans(x,pl->top[x-1],pl->bottom[x-1],pl->top[x],pl->bottom[x]);

--- a/Source/r_plane.c
+++ b/Source/r_plane.c
@@ -66,13 +66,13 @@ visplane_t *floorplane, *ceilingplane;
 // killough 8/1/98: set static number of openings to be large enough
 // (a static limit is okay in this case and avoids difficulties in r_segs.c)
 #define MAXOPENINGS (MAX_SCREENWIDTH*MAX_SCREENHEIGHT)
-int openings[MAXOPENINGS],*lastopening;
+int openings[MAXOPENINGS],*lastopening; // [FG] 32-bit integer math
 
 // Clip values are the solid pixel bounding the range.
 //  floorclip starts out SCREENHEIGHT
 //  ceilingclip starts out -1
 
-int floorclip[MAX_SCREENWIDTH], ceilingclip[MAX_SCREENWIDTH];
+int floorclip[MAX_SCREENWIDTH], ceilingclip[MAX_SCREENWIDTH]; // [FG] 32-bit integer math
 
 // spanstart holds the start of a plane span; initialized to 0 at start
 
@@ -269,7 +269,7 @@ visplane_t *R_CheckPlane(visplane_t *pl, int start, int stop)
   else
     unionh  = pl->maxx, intrh  = stop;
 
-  for (x=intrl ; x <= intrh && pl->top[x] == 0xffffffffu; x++)
+  for (x=intrl ; x <= intrh && pl->top[x] == 0xffffffffu; x++) // [FG] 32-bit integer math
     ;
 
   if (x > intrh)
@@ -297,7 +297,7 @@ visplane_t *R_CheckPlane(visplane_t *pl, int start, int stop)
 // R_MakeSpans
 //
 
-static void R_MakeSpans(int x, unsigned int t1, unsigned int b1, unsigned int t2, unsigned int b2)
+static void R_MakeSpans(int x, unsigned int t1, unsigned int b1, unsigned int t2, unsigned int b2) // [FG] 32-bit integer math
 {
   for (; t1 < t2 && t1 <= b1; t1++)
     R_MapPlane(t1, spanstart[t1], x-1);
@@ -378,7 +378,7 @@ static void do_draw_plane(visplane_t *pl)
 
 	// killough 10/98: Use sky scrolling offset, and possibly flip picture
         for (x = pl->minx; (dc_x = x) <= pl->maxx; x++)
-          if ((unsigned)(dc_yl = pl->top[x]) <= (dc_yh = pl->bottom[x]))
+          if ((unsigned)(dc_yl = pl->top[x]) <= (dc_yh = pl->bottom[x])) // [FG] 32-bit integer math
             {
               dc_source = R_GetColumn(texture, ((an + xtoviewangle[x])^flip) >>
 				      ANGLETOSKYSHIFT);
@@ -405,7 +405,7 @@ static void do_draw_plane(visplane_t *pl)
 
         stop = pl->maxx + 1;
         planezlight = zlight[light];
-        pl->top[pl->minx-1] = pl->top[stop] = 0xffffffffu;
+        pl->top[pl->minx-1] = pl->top[stop] = 0xffffffffu; // [FG] 32-bit integer math
 
         for (x = pl->minx ; x <= stop ; x++)
           R_MakeSpans(x,pl->top[x-1],pl->bottom[x-1],pl->top[x],pl->bottom[x]);

--- a/Source/r_plane.h
+++ b/Source/r_plane.h
@@ -35,9 +35,9 @@
 #define PL_SKYFLAT (0x80000000)
 
 // Visplane related.
-extern  short *lastopening;
+extern  int *lastopening;
 
-extern short floorclip[], ceilingclip[];
+extern int floorclip[], ceilingclip[];
 extern fixed_t yslope[], distscale[];
 
 void R_InitPlanes(void);

--- a/Source/r_plane.h
+++ b/Source/r_plane.h
@@ -35,9 +35,9 @@
 #define PL_SKYFLAT (0x80000000)
 
 // Visplane related.
-extern  int *lastopening;
+extern  int *lastopening; // [FG] 32-bit integer math
 
-extern int floorclip[], ceilingclip[];
+extern int floorclip[], ceilingclip[]; // [FG] 32-bit integer math
 extern fixed_t yslope[], distscale[];
 
 void R_InitPlanes(void);

--- a/Source/r_segs.c
+++ b/Source/r_segs.c
@@ -81,7 +81,7 @@ static fixed_t  topfrac;
 static fixed_t  topstep;
 static fixed_t  bottomfrac;
 static fixed_t  bottomstep;
-static int    *maskedtexturecol;
+static int    *maskedtexturecol; // [FG] 32-bit integer math
 
 //
 // R_RenderMaskedSegRange
@@ -158,7 +158,7 @@ void R_RenderMaskedSegRange(drawseg_t *ds, int x1, int x2)
 
   // draw the columns
   for (dc_x = x1 ; dc_x <= x2 ; dc_x++, spryscale += rw_scalestep)
-    if (maskedtexturecol[dc_x] != D_MAXINT)
+    if (maskedtexturecol[dc_x] != D_MAXINT) // [FG] 32-bit integer math
       {
         if (!fixedcolormap)      // calculate lighting
           {                             // killough 11/98:
@@ -203,7 +203,7 @@ void R_RenderMaskedSegRange(drawseg_t *ds, int x1, int x2)
         col = (column_t *)((byte *)
                            R_GetColumn(texnum,maskedtexturecol[dc_x]) - 3);
         R_DrawMaskedColumn (col);
-        maskedtexturecol[dc_x] = D_MAXINT;
+        maskedtexturecol[dc_x] = D_MAXINT; // [FG] 32-bit integer math
       }
 
   // Except for main_tranmap, mark others purgable at this point
@@ -729,13 +729,13 @@ void R_StoreWallRange(const int start, const int stop)
   // save sprite clipping info
   if ((ds_p->silhouette & SIL_TOP || maskedtexture) && !ds_p->sprtopclip)
     {
-      memcpy (lastopening, ceilingclip+start, sizeof(*lastopening)*(rw_stopx-start));
+      memcpy (lastopening, ceilingclip+start, sizeof(*lastopening)*(rw_stopx-start)); // [FG] 32-bit integer math
       ds_p->sprtopclip = lastopening - start;
       lastopening += rw_stopx - start;
     }
   if ((ds_p->silhouette & SIL_BOTTOM || maskedtexture) && !ds_p->sprbottomclip)
     {
-      memcpy (lastopening, floorclip+start, sizeof(*lastopening)*(rw_stopx-start));
+      memcpy (lastopening, floorclip+start, sizeof(*lastopening)*(rw_stopx-start)); // [FG] 32-bit integer math
       ds_p->sprbottomclip = lastopening - start;
       lastopening += rw_stopx - start;
     }

--- a/Source/r_segs.c
+++ b/Source/r_segs.c
@@ -81,7 +81,7 @@ static fixed_t  topfrac;
 static fixed_t  topstep;
 static fixed_t  bottomfrac;
 static fixed_t  bottomstep;
-static short    *maskedtexturecol;
+static int    *maskedtexturecol;
 
 //
 // R_RenderMaskedSegRange
@@ -158,7 +158,7 @@ void R_RenderMaskedSegRange(drawseg_t *ds, int x1, int x2)
 
   // draw the columns
   for (dc_x = x1 ; dc_x <= x2 ; dc_x++, spryscale += rw_scalestep)
-    if (maskedtexturecol[dc_x] != D_MAXSHORT)
+    if (maskedtexturecol[dc_x] != D_MAXINT)
       {
         if (!fixedcolormap)      // calculate lighting
           {                             // killough 11/98:
@@ -203,7 +203,7 @@ void R_RenderMaskedSegRange(drawseg_t *ds, int x1, int x2)
         col = (column_t *)((byte *)
                            R_GetColumn(texnum,maskedtexturecol[dc_x]) - 3);
         R_DrawMaskedColumn (col);
-        maskedtexturecol[dc_x] = D_MAXSHORT;
+        maskedtexturecol[dc_x] = D_MAXINT;
       }
 
   // Except for main_tranmap, mark others purgable at this point
@@ -729,13 +729,13 @@ void R_StoreWallRange(const int start, const int stop)
   // save sprite clipping info
   if ((ds_p->silhouette & SIL_TOP || maskedtexture) && !ds_p->sprtopclip)
     {
-      memcpy (lastopening, ceilingclip+start, 2*(rw_stopx-start));
+      memcpy (lastopening, ceilingclip+start, sizeof(*lastopening)*(rw_stopx-start));
       ds_p->sprtopclip = lastopening - start;
       lastopening += rw_stopx - start;
     }
   if ((ds_p->silhouette & SIL_BOTTOM || maskedtexture) && !ds_p->sprbottomclip)
     {
-      memcpy (lastopening, floorclip+start, 2*(rw_stopx-start));
+      memcpy (lastopening, floorclip+start, sizeof(*lastopening)*(rw_stopx-start));
       ds_p->sprbottomclip = lastopening - start;
       lastopening += rw_stopx - start;
     }

--- a/Source/r_things.c
+++ b/Source/r_things.c
@@ -63,8 +63,8 @@ static lighttable_t **spritelights;        // killough 1/25/98 made static
 // constant arrays
 //  used for psprite clipping and initializing clipping
 
-short negonearray[MAX_SCREENWIDTH];        // killough 2/8/98:
-short screenheightarray[MAX_SCREENWIDTH];  // change to MAX_*
+int negonearray[MAX_SCREENWIDTH];        // killough 2/8/98:
+int screenheightarray[MAX_SCREENWIDTH];  // change to MAX_*
 
 //
 // INITIALIZATION FUNCTIONS
@@ -303,8 +303,8 @@ vissprite_t *R_NewVisSprite(void)
 //  in posts/runs of opaque pixels.
 //
 
-short   *mfloorclip;
-short   *mceilingclip;
+int   *mfloorclip;
+int   *mceilingclip;
 fixed_t spryscale;
 fixed_t sprtopscreen;
 
@@ -819,8 +819,8 @@ void R_SortVisSprites (void)
 void R_DrawSprite (vissprite_t* spr)
 {
   drawseg_t *ds;
-  short   clipbot[MAX_SCREENWIDTH];       // killough 2/8/98:
-  short   cliptop[MAX_SCREENWIDTH];       // change to MAX_*
+  int   clipbot[MAX_SCREENWIDTH];       // killough 2/8/98:
+  int   cliptop[MAX_SCREENWIDTH];       // change to MAX_*
   int     x;
   int     r1;
   int     r2;

--- a/Source/r_things.c
+++ b/Source/r_things.c
@@ -63,6 +63,7 @@ static lighttable_t **spritelights;        // killough 1/25/98 made static
 // constant arrays
 //  used for psprite clipping and initializing clipping
 
+// [FG] 32-bit integer math
 int negonearray[MAX_SCREENWIDTH];        // killough 2/8/98:
 int screenheightarray[MAX_SCREENWIDTH];  // change to MAX_*
 
@@ -303,8 +304,8 @@ vissprite_t *R_NewVisSprite(void)
 //  in posts/runs of opaque pixels.
 //
 
-int   *mfloorclip;
-int   *mceilingclip;
+int   *mfloorclip; // [FG] 32-bit integer math
+int   *mceilingclip; // [FG] 32-bit integer math
 fixed_t spryscale;
 fixed_t sprtopscreen;
 
@@ -819,6 +820,7 @@ void R_SortVisSprites (void)
 void R_DrawSprite (vissprite_t* spr)
 {
   drawseg_t *ds;
+  // [FG] 32-bit integer math
   int   clipbot[MAX_SCREENWIDTH];       // killough 2/8/98:
   int   cliptop[MAX_SCREENWIDTH];       // change to MAX_*
   int     x;

--- a/Source/r_things.h
+++ b/Source/r_things.h
@@ -35,13 +35,14 @@
 
 // Constant arrays used for psprite clipping and initializing clipping.
 
+// [FG] 32-bit integer math
 extern int negonearray[MAX_SCREENWIDTH];         // killough 2/8/98:
 extern int screenheightarray[MAX_SCREENWIDTH];   // change to MAX_*
 
 // Vars for R_DrawMaskedColumn
 
-extern int   *mfloorclip;
-extern int   *mceilingclip;
+extern int   *mfloorclip; // [FG] 32-bit integer math
+extern int   *mceilingclip; // [FG] 32-bit integer math
 extern fixed_t spryscale;
 extern fixed_t sprtopscreen;
 extern fixed_t pspritescale;

--- a/Source/r_things.h
+++ b/Source/r_things.h
@@ -35,13 +35,13 @@
 
 // Constant arrays used for psprite clipping and initializing clipping.
 
-extern short negonearray[MAX_SCREENWIDTH];         // killough 2/8/98:
-extern short screenheightarray[MAX_SCREENWIDTH];   // change to MAX_*
+extern int negonearray[MAX_SCREENWIDTH];         // killough 2/8/98:
+extern int screenheightarray[MAX_SCREENWIDTH];   // change to MAX_*
 
 // Vars for R_DrawMaskedColumn
 
-extern short   *mfloorclip;
-extern short   *mceilingclip;
+extern int   *mfloorclip;
+extern int   *mceilingclip;
 extern fixed_t spryscale;
 extern fixed_t sprtopscreen;
 extern fixed_t pspritescale;


### PR DESCRIPTION
This avoids crashes in maps with extreme heights or height differences,
e.g. ludicrm.wad map03.